### PR TITLE
initial pass at startup benchmark

### DIFF
--- a/benchmarks/src/main/java/com/fasterxml/jackson/module/blackbird/StartupTimeBenchmark.java
+++ b/benchmarks/src/main/java/com/fasterxml/jackson/module/blackbird/StartupTimeBenchmark.java
@@ -1,0 +1,59 @@
+package com.fasterxml.jackson.module.blackbird;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.blackbird.BaseBenchmark.SomeBean;
+import com.fasterxml.jackson.module.blackbird.BaseBenchmark.SomeBean.SomeEnum;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@Measurement(iterations = 1)
+@Warmup(iterations = 0)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(10)
+public class StartupTimeBenchmark {
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+            .include(StartupTimeBenchmark.class.getSimpleName())
+            .build();
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    public byte[] vanilla() throws Exception {
+        return singleShot(new ObjectMapper());
+    }
+
+    @Benchmark
+    public byte[] blackbird() throws Exception {
+        return singleShot(new ObjectMapper().registerModule(new BlackbirdModule()));
+    }
+
+    @Benchmark
+    public byte[] afterburner() throws Exception {
+        return singleShot(new ObjectMapper().registerModule(new AfterburnerModule()));
+    }
+
+    private static byte[] singleShot(ObjectMapper mapper) throws JsonProcessingException {
+        final Random random = new Random();
+        return mapper.writeValueAsBytes(List.of(
+                SomeBean.random(random),
+                new BaseBenchmark.ClassicBean().setUp(),
+                new BaseBenchmark.BeanWithPropertyConstructor(42, "foo", 8675309, SomeBean.random(random), SomeEnum.EB)));
+    }
+}


### PR DESCRIPTION
```
# JMH version: 1.21
# VM version: JDK 12, OpenJDK 64-Bit Server VM, 12+33
# VM invoker: /usr/lib/jvm/java-12-openjdk-12.0.0.33-1.ea.1.rolling.fc29.x86_64/bin/java
# VM options: <none>
# Warmup: <none>
# Measurement: 1 iterations, single-shot each
# Timeout: 10 min per iteration
# Threads: 1 thread
# Benchmark mode: Single shot invocation time


Benchmark                         Mode  Cnt    Score   Error  Units
StartupTimeBenchmark.afterburner    ss  100  170.105 ± 2.128  ms/op
StartupTimeBenchmark.blackbird      ss  100  167.366 ± 2.394  ms/op
StartupTimeBenchmark.vanilla        ss  100  147.506 ± 1.609  ms/op

# JMH version: 1.21
# VM version: JDK 11.0.2, OpenJDK 64-Bit Server VM, 11.0.2+7
# VM invoker: /usr/lib/jvm/java-11-openjdk-11.0.2.7-0.fc29.x86_64/bin/java
# VM options: <none>
# Warmup: <none>
# Measurement: 1 iterations, single-shot each
# Timeout: 10 min per iteration
# Threads: 1 thread
# Benchmark mode: Single shot invocation time

Benchmark                         Mode  Cnt    Score   Error  Units
StartupTimeBenchmark.afterburner    ss  100  170.120 ± 2.499  ms/op
StartupTimeBenchmark.blackbird      ss  100  177.206 ± 3.641  ms/op
StartupTimeBenchmark.vanilla        ss  100  157.618 ± 3.119  ms/op
```